### PR TITLE
refactor BioMarkerResult to IterableResult

### DIFF
--- a/src/main/groovy/org/transmartproject/core/IterableResult.groovy
+++ b/src/main/groovy/org/transmartproject/core/IterableResult.groovy
@@ -1,0 +1,10 @@
+package org.transmartproject.core
+
+/**
+ * The result of a query that provides a list of results in the form of an iterable.
+ *
+ * In general, the iterator can be fetched only once.
+ *
+ * @param < I > The type of the results themselves
+ */
+interface IterableResult<I> extends Closeable, Iterable<I> {}

--- a/src/main/groovy/org/transmartproject/core/biomarker/BioMarkerResource.groovy
+++ b/src/main/groovy/org/transmartproject/core/biomarker/BioMarkerResource.groovy
@@ -1,5 +1,7 @@
 package org.transmartproject.core.biomarker
 
+import org.transmartproject.core.IterableResult
+
 /**
  *
  */
@@ -10,7 +12,7 @@ interface BioMarkerResource {
      * @param constraints for limiting the bio markers in the result
      * @return scrollable collection of result bio markers.
      */
-    BioMarkerResult retrieveBioMarkers(List<BioMarkerConstraint> constraints)
+    IterableResult<BioMarker> retrieveBioMarkers(List<BioMarkerConstraint> constraints)
 
     /**
      * Instantiate certain type of constraint object.

--- a/src/main/groovy/org/transmartproject/core/biomarker/BioMarkerResult.groovy
+++ b/src/main/groovy/org/transmartproject/core/biomarker/BioMarkerResult.groovy
@@ -1,9 +1,0 @@
-package org.transmartproject.core.biomarker
-
-/**
- * The type returned by
- * {@link BioMarkerResource#retrieveBioMarkers(List<BioMarkerConstraint>)}.
- *
- * In general, the iterator can be fetched only once.
- */
-interface BioMarkerResult extends Closeable, Iterable<BioMarker> {}

--- a/src/main/groovy/org/transmartproject/core/dataquery/TabularResult.groovy
+++ b/src/main/groovy/org/transmartproject/core/dataquery/TabularResult.groovy
@@ -1,5 +1,7 @@
 package org.transmartproject.core.dataquery
 
+import org.transmartproject.core.IterableResult
+
 /**
  * The result of a data query that provides a list of indices (columns) that
  * can be used to fetch individual values from the rows,
@@ -8,7 +10,7 @@ package org.transmartproject.core.dataquery
  * @param < I > The type for the row indexes
  * @param < R > The type for the rows themselves
  */
-public interface TabularResult<I extends DataColumn, R extends DataRow> extends Closeable, Iterable<R> {
+public interface TabularResult<I extends DataColumn, R extends DataRow> extends IterableResult<R> {
 
     /**
      * Used to obtain the "columns" of the result set' the indices used to


### PR DESCRIPTION
BioMarkerResult does not add anything specific to BioMarkers, it just exposes an iterable query result. This change generalizes that into an IterableResult. The return type of BioMarkerResource.retrieveBioMarkers is changed to IterableResult<BioMarker>.

BioMarkerResource and BioMarkerResult are not yet used anywhere in transmart, at least not in any of the repo'd parts of it, so it should not be a problem to change the api now. @forus Do you know if BioMarkerResource/Result is being used anywhere in third party plugins?